### PR TITLE
Prevent last user deletion

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -67,6 +67,11 @@ class UsersController < ApplicationController
     end
   end
 
+  rescue_from 'User::Error' do |exception|
+    flash[:error] = exception.message
+    redirect_to users_url
+  end
+
   private
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,15 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: { case_sensitive: false }
   has_secure_password
+
+  after_destroy :ensure_an_admin_remains
+
+  class Error < StandardError
+  end
+
+  def ensure_an_admin_remains
+    if User.count.zero?
+      raise Error, "Can't delete last user!"
+    end
+  end
 end


### PR DESCRIPTION
## Aim
Prevents the last user from being deleted

## How?
1. add an `after_destroy` hook to the user model which check if there are any users left in the database
1. if not, an exception is raised, the user is added back in and an error message is displayed

## Notes
No
